### PR TITLE
追加実装 エラーメッセージの日本語化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,3 +64,4 @@ gem 'image_processing', '~> 1.2'
 gem 'active_hash'
 gem 'payjp'
 gem "aws-sdk-s3", require: false
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,6 +195,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
+    rails-i18n (7.0.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.0.4.7)
       actionpack (= 6.0.4.7)
       activesupport (= 6.0.4.7)
@@ -333,6 +336,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rspec-rails (~> 4.0.0)
   rubocop
   sass-rails (~> 5)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -16,7 +16,7 @@ class Item < ApplicationRecord
     validates :explanation
   end
 
-  with_options numericality: { other_than: 1, message: "can't be blank" } do
+  with_options numericality: { other_than: 1, message: "を入力してください" } do
     validates :category_id
     validates :sales_state_id
     validates :postage_id
@@ -25,5 +25,5 @@ class Item < ApplicationRecord
   end
 
   validates :price, presence: true,
-                    numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: ' is out of setting range' }
+                    numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: 'は¥300〜9,999,999の範囲で入力してください' }
 end

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -4,16 +4,16 @@ class OrderAddress
 
   with_options presence: true do
     validates :token
-    validates :post_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: 'is invalid. Enter it as follows (e.g. 123-4567)' }
+    validates :post_code, format: { with: /\A[0-9]{3}-[0-9]{4}\z/, message: 'はハイフンで区切ってください (例 123-4567)' }
     validates :city
     validates :block
-    validates :phone_number, format: { with: /\A[0-9]+\z/, message: 'is invalid. Input only number' },
-                             length: { minimum: 10, maximum: 11, message: 'is too short' }
+    validates :phone_number, format: { with: /\A[0-9]+\z/, message: 'は半角数字のみで入力してください' },
+                             length: { minimum: 10, maximum: 11, message: 'が短かすぎます' }
     validates :user_id
     validates :item_id
   end
 
-  validates :prefecture_id, numericality: { other_than: 1, message: "can't be blank" }
+  validates :prefecture_id, numericality: { other_than: 1, message: "を入力してください" }
 
   def save
     order = Order.create(item_id: item_id, user_id: user_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,13 +15,13 @@ class User < ApplicationRecord
   validates :birthday, presence: true
 
   PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
-  validates_format_of :password, with: PASSWORD_REGEX, message: ' is invalid. Include both letters and numbers'
+  validates_format_of :password, with: PASSWORD_REGEX, message: 'は文字と数字の両方を含めてください'
 
   NAME_REGEX = /\A[ぁ-んァ-ン一-龥々ーａ-ｚＡ-Ｚ]+\z/u.freeze
-  validates_format_of :last_name, with: NAME_REGEX, message: ' is invalid. Input full-width characters'
-  validates_format_of :first_name, with: NAME_REGEX, message: ' is invalid. Input full-width characters'
+  validates_format_of :last_name, with: NAME_REGEX, message: 'は全角文字で入力してください'
+  validates_format_of :first_name, with: NAME_REGEX, message: 'は全角文字で入力してください'
 
   RUBY_REGEX = /\A[ァ-ヶー－]+\z/u.freeze
-  validates_format_of :last_name_ruby, with: RUBY_REGEX, message: ' Input full-width katakana characters'
-  validates_format_of :first_name_ruby, with: RUBY_REGEX, message: ' Input full-width katakana characters'
+  validates_format_of :last_name_ruby, with: RUBY_REGEX, message: 'は全角カナで入力してください'
+  validates_format_of :first_name_ruby, with: RUBY_REGEX, message: 'は全角カナで入力してください'
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ module Furima37653
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    config.i18n.default_locale = :ja
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,32 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        nickname: ニックネーム
+        last_name: 苗字
+        first_name: 名前
+        last_name_ruby: 苗字カナ
+        first_name_ruby: 名前カナ
+        birthday: 生年月日
+        is_invalid: は無効です
+
+      item:
+        image: 商品画像
+        product: 商品名
+        explanation: 商品の説明
+        category_id: カテゴリー
+        sales_state_id: 商品の状態
+        postage_id: 配送料の負担
+        prefecture_id: 発送元の地域
+        post_period_id: 発送までの日数
+        price: 販売価格
+
+  activemodel:
+    attributes:
+      order_address:
+        token: カード情報
+        post_code: 郵便番号
+        city: 市区町村
+        block: 番地
+        phone_number: 電話番号
+        prefecture_id: 都道府県

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -16,70 +16,69 @@ RSpec.describe Item, type: :model do
       it '商品画像が添付されないと出品できない' do
         @item.image = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Image can't be blank")
+        expect(@item.errors.full_messages).to include("商品画像を入力してください")
       end
 
       it '商品名が空白だと出品できない' do
         @item.product = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Product can't be blank")
+        expect(@item.errors.full_messages).to include("商品名を入力してください")
       end
 
       it '商品の説明が空白だと出品できない' do
         @item.explanation = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Explanation can't be blank")
+        expect(@item.errors.full_messages).to include("商品の説明を入力してください")
       end
       it 'カテゴリーの情報が空白（初期値1のまま）だと出品できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category can't be blank")
+        expect(@item.errors.full_messages).to include("カテゴリーを入力してください")
       end
       it '商品の状態の情報が空白（初期値1のまま）だと出品できない' do
         @item.sales_state_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Sales state can't be blank")
+        expect(@item.errors.full_messages).to include("商品の状態を入力してください")
       end
       it '配送料の負担の情報が空白（初期値1のまま）だと出品できない' do
         @item.postage_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Postage can't be blank")
+        expect(@item.errors.full_messages).to include("配送料の負担を入力してください")
       end
       it '発送元の地域の情報が空白（初期値1のまま）だと出品できない' do
         @item.prefecture_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture can't be blank")
+        expect(@item.errors.full_messages).to include("発送元の地域を入力してください")
       end
       it '発送までの日数の情報が空白（初期値1のまま）だと出品できない' do
         @item.post_period_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Post period can't be blank")
+        expect(@item.errors.full_messages).to include("発送までの日数を入力してください")
       end
       it '価格の情報がが空白だと出品できない' do
         @item.price = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price can't be blank")
+        expect(@item.errors.full_messages).to include("販売価格を入力してください")
       end
       it '価格の情報が、¥300未満だと出品できない' do
         @item.price = 299
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price  is out of setting range')
+        expect(@item.errors.full_messages).to include('販売価格は¥300〜9,999,999の範囲で入力してください')
       end
       it '価格の情報が、¥9999999を超えると出品できない' do
         @item.price = 10_000_000
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price  is out of setting range')
+        expect(@item.errors.full_messages).to include('販売価格は¥300〜9,999,999の範囲で入力してください')
       end
-
       it '価格は半角数値でないと（全角数字）だと出品できない' do
         @item.price = '５００'
         @item.valid?
-        expect(@item.errors.full_messages).to include('Price  is out of setting range')
+        expect(@item.errors.full_messages).to include('販売価格は¥300〜9,999,999の範囲で入力してください')
       end
       it 'user情報が関連づいていないと出品できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include('User must exist')
+        expect(@item.errors.full_messages).to include('Userを入力してください')
       end
     end
   end

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -23,72 +23,72 @@ RSpec.describe OrderAddress, type: :model do
       it 'tokenが空白(カード認証ができない)場合は購入できない' do
         @order_address.token = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include("Token can't be blank")
+        expect(@order_address.errors.full_messages).to include("カード情報を入力してください")
       end
       it '郵便番号が空白だと購入できない' do
         @order_address.post_code = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include("Post code can't be blank")
+        expect(@order_address.errors.full_messages).to include("郵便番号を入力してください")
       end
       it '郵便番号にハイフンがない場合は購入できない' do
         @order_address.post_code = '1234567'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include('Post code is invalid. Enter it as follows (e.g. 123-4567)')
+        expect(@order_address.errors.full_messages).to include('郵便番号はハイフンで区切ってください (例 123-4567)')
       end
       it '郵便番号が「3桁ハイフン4桁」でない場合は購入できない' do
         @order_address.post_code = '1234-567'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include('Post code is invalid. Enter it as follows (e.g. 123-4567)')
+        expect(@order_address.errors.full_messages).to include('郵便番号はハイフンで区切ってください (例 123-4567)')
       end
       it '郵便番号が半角数字でない場合は購入できない' do
         @order_address.post_code = '１２３−４５６７'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include('Post code is invalid. Enter it as follows (e.g. 123-4567)')
+        expect(@order_address.errors.full_messages).to include('郵便番号はハイフンで区切ってください (例 123-4567)')
       end
       it '都道府県が空白 (prefecture_id = 1)の場合は購入できない' do
         @order_address.prefecture_id = 1
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include("Prefecture can't be blank")
+        expect(@order_address.errors.full_messages).to include("都道府県を入力してください")
       end
       it '市区町村が空白の場合は購入できない' do
         @order_address.city = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include("City can't be blank")
+        expect(@order_address.errors.full_messages).to include("市区町村を入力してください")
       end
       it '番地が空白の場合は購入できない' do
         @order_address.block = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include("Block can't be blank")
+        expect(@order_address.errors.full_messages).to include("番地を入力してください")
       end
       it '電話番号が空白だと登録できない' do
         @order_address.phone_number = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include("Phone number can't be blank")
+        expect(@order_address.errors.full_messages).to include("電話番号を入力してください")
       end
       it '電話番号にハイフンが含まれている場合は登録できない' do
         @order_address.phone_number = '000-00-0000'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include('Phone number is invalid. Input only number')
+        expect(@order_address.errors.full_messages).to include('電話番号は半角数字のみで入力してください')
       end
       it '電話番号が10桁未満だと購入できない' do
         @order_address.phone_number = '123456789'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include('Phone number is too short')
+        expect(@order_address.errors.full_messages).to include('電話番号が短かすぎます')
       end
       it '電話番号が12桁以上だと購入できない' do
         @order_address.phone_number = '123456789012'
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include('Phone number is too short')
+        expect(@order_address.errors.full_messages).to include('電話番号が短かすぎます')
       end
       it 'user情報がない（ログイン状態でない）と登録できない' do
         @order_address.user_id = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include("User can't be blank")
+        expect(@order_address.errors.full_messages).to include("Userを入力してください")
       end
       it 'item情報と関連づいていないと登録できない' do
         @order_address.item_id = ''
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include("Item can't be blank")
+        expect(@order_address.errors.full_messages).to include("Itemを入力してください")
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe User, type: :model do
       it 'ニックネームが空白だと登録できない' do
         @user.nickname = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Nickname can't be blank")
+        expect(@user.errors.full_messages).to include("ニックネームを入力してください")
       end
 
       it 'メールアドレスが空白だと登録できない' do
         @user.email = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Email can't be blank")
+        expect(@user.errors.full_messages).to include("Eメールを入力してください")
       end
 
       it 'すでに登録されたメールアドレスでは登録できない' do
@@ -30,120 +30,120 @@ RSpec.describe User, type: :model do
         other_user = FactoryBot.build(:user)
         other_user.email = @user.email
         other_user.valid?
-        expect(other_user.errors.full_messages).to include('Email has already been taken')
+        expect(other_user.errors.full_messages).to include('Eメールはすでに存在します')
       end
 
       it 'メールアドレスは、@を含まないと登録できない' do
         @user.email = 'testmail.com'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Email is invalid')
+        expect(@user.errors.full_messages).to include('Eメールは不正な値です')
       end
 
       it 'パスワードが空白だと登録できない' do
         @user.password = ''
         @user.password_confirmation = @user.password
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password can't be blank")
+        expect(@user.errors.full_messages).to include("パスワードを入力してください")
       end
 
       it 'パスワードは、6文字以上でないと登録できない' do
         @user.password = 'p1234'
         @user.password_confirmation = @user.password
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
+        expect(@user.errors.full_messages).to include('パスワードは6文字以上で入力してください')
       end
 
       it 'パスワードは、半角数字のみでは登録できない' do
         @user.password = '123456'
         @user.password_confirmation = @user.password
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password  is invalid. Include both letters and numbers')
+        expect(@user.errors.full_messages).to include('パスワードは文字と数字の両方を含めてください')
       end
 
       it 'パスワードは、半角英数字のみでは登録できない' do
         @user.password = 'password'
         @user.password_confirmation = @user.password
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password  is invalid. Include both letters and numbers')
+        expect(@user.errors.full_messages).to include('パスワードは文字と数字の両方を含めてください')
       end
 
       it 'パスワードとパスワード（確認）は、値の一致しないと登録できない' do
         @user.password = 'password2'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+        expect(@user.errors.full_messages).to include("パスワード（確認用）とパスワードの入力が一致しません")
       end
 
       it 'パスワードは、全角での入力では登録できない' do
         @user.password = 'ｐ１２３４５'
         @user.password_confirmation = @user.password
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password  is invalid. Include both letters and numbers')
+        expect(@user.errors.full_messages).to include('パスワードは文字と数字の両方を含めてください')
       end
 
       it '苗字が空白だと登録できない' do
         @user.last_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name can't be blank")
+        expect(@user.errors.full_messages).to include("苗字を入力してください")
       end
 
       it '名前がが空白だと登録できない' do
         @user.first_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name can't be blank")
+        expect(@user.errors.full_messages).to include("名前を入力してください")
       end
 
       it '苗字が半角だと登録できない' do
         @user.last_name = 'ﾐｮｳｼﾞ'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last name  is invalid. Input full-width characters')
+        expect(@user.errors.full_messages).to include('苗字は全角文字で入力してください')
       end
 
       it '名前が半角だと登録できない' do
         @user.first_name = 'ﾅﾏｴ'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First name  is invalid. Input full-width characters')
+        expect(@user.errors.full_messages).to include('名前は全角文字で入力してください')
       end
 
       it '苗字カナが空白だと登録できない' do
         @user.last_name_ruby = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Last name ruby can't be blank")
+        expect(@user.errors.full_messages).to include("苗字カナを入力してください")
       end
 
       it '名前カナが空白だと登録できない' do
         @user.first_name_ruby = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("First name ruby can't be blank")
+        expect(@user.errors.full_messages).to include("名前カナを入力してください")
       end
 
       it '苗字カナが半角だと登録できない' do
         @user.last_name_ruby = 'ﾐｮｳｼﾞ'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last name ruby  Input full-width katakana characters')
+        expect(@user.errors.full_messages).to include('苗字カナは全角カナで入力してください')
       end
 
       it '苗字カナが全角でもカタカナ以外だと登録できない' do
         @user.last_name_ruby = 'みょうじ'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Last name ruby  Input full-width katakana characters')
+        expect(@user.errors.full_messages).to include('苗字カナは全角カナで入力してください')
       end
 
       it '名前カナが半角だと登録できない' do
         @user.first_name_ruby = 'ﾅﾏｴ'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First name ruby  Input full-width katakana characters')
+        expect(@user.errors.full_messages).to include('名前カナは全角カナで入力してください')
       end
 
       it '名前カナが全角でもカタカナ以外だと登録できない' do
         @user.first_name_ruby = 'なまえ'
         @user.valid?
-        expect(@user.errors.full_messages).to include('First name ruby  Input full-width katakana characters')
+        expect(@user.errors.full_messages).to include('名前カナは全角カナで入力してください')
       end
 
       it '生年月日が空白だと登録できない' do
         @user.birthday = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Birthday can't be blank")
+        expect(@user.errors.full_messages).to include("生年月日を入力してください")
       end
     end
   end


### PR DESCRIPTION
# What
- Gem 'rails-i18n'の追加
- devise.ya.ymlファイルの作成
- ja.ymlファイルの作成/日本語化ワードの定義 >> user/item/order_address
- user/item/order_addressモデルのエラーメッセージを日本語化
- user/item/order_addressテストコードを日本語化対応

# Why
- エラーメッセージの日本語化機能を実装するため